### PR TITLE
Do not check interestOps() on an invalid key

### DIFF
--- a/modules/jetty/src/main/java/org/mortbay/io/nio/SelectorManager.java
+++ b/modules/jetty/src/main/java/org/mortbay/io/nio/SelectorManager.java
@@ -529,7 +529,7 @@ public abstract class SelectorManager extends AbstractLifeCycle
                         {
                             key=(SelectionKey)sweep.next();
 
-                            if (!key.isValid() && key.interestOps()==0)
+                            if (!key.isValid())
                             {
                                 try
                                 {


### PR DESCRIPTION
Calling interestOps() on invalid keys always results in CancelledKeyException and the rest of the operation in the doSelect() method is never executed.
